### PR TITLE
Minor cleanups

### DIFF
--- a/src/devices/bus.rs
+++ b/src/devices/bus.rs
@@ -75,12 +75,12 @@ impl Bus for TerminusBus {
             .find(|entry| {
                 if let Some(lock_owner) = entry.lock_holder(addr, len) {
                     if who == lock_owner {
-                        panic!(format!(
+                        panic!(
                             "master {} try to lock {:#x} - {:#x} twice!",
                             who,
                             *addr,
                             *addr + len as u64
-                        ))
+                        )
                     }
                     true
                 } else {
@@ -119,7 +119,7 @@ impl Bus for TerminusBus {
                 if who == lock_owner {
                     true
                 } else {
-                    panic!(format!("master {} try to release {:#x} - {:#x} but haven't owned the lock! lock_table:{:?}", who, *addr, *addr + len as u64, lock_table))
+                    panic!("master {} try to release {:#x} - {:#x} but haven't owned the lock! lock_table:{:?}", who, *addr, *addr + len as u64, lock_table)
                 }
             } else {
                 false
@@ -127,7 +127,7 @@ impl Bus for TerminusBus {
         }) {
             lock_table.remove(i);
         } else {
-            panic!(format!("master {} try to release {:#x} - {:#x} but haven't owned the lock! lock_table:{:?}", who, addr, *addr + len as u64, lock_table))
+            panic!("master {} try to release {:#x} - {:#x} but haven't owned the lock! lock_table:{:?}", who, addr, *addr + len as u64, lock_table)
         }
     }
     #[cfg_attr(feature = "no-inline", inline(never))]

--- a/src/devices/clint.rs
+++ b/src/devices/clint.rs
@@ -133,7 +133,7 @@ impl U32Access for Clint {
     fn write(&self, addr: &u64, data: u32) {
         assert!(
             (*addr).trailing_zeros() > 1,
-            format!("U32Access:unaligned addr:{:#x}", addr)
+            "U32Access:unaligned addr:{:#x}", addr
         );
         let mut timer = self.0.inner_mut();
         if *addr >= MSIP_BASE && *addr + 4 <= MSIP_BASE + timer.sints.len() as u64 * MSIP_SIZE {
@@ -163,13 +163,13 @@ impl U32Access for Clint {
             };
         }
 
-        panic!("clint:U32Access Invalid addr!".to_string());
+        panic!("clint:U32Access Invalid addr!");
     }
 
     fn read(&self, addr: &u64) -> u32 {
         assert!(
             (*addr).trailing_zeros() > 1,
-            format!("U32Access:unaligned addr:{:#x}", addr)
+            "U32Access:unaligned addr:{:#x}", addr
         );
         let timer = self.0.inner();
         if *addr >= MSIP_BASE && *addr + 4 <= MSIP_BASE + timer.sint_status.len() as u64 * MSIP_SIZE
@@ -193,7 +193,7 @@ impl U32Access for Clint {
             } as u32;
         }
 
-        panic!("clint:U32Access Invalid addr!".to_string());
+        panic!("clint:U32Access Invalid addr!");
     }
 }
 
@@ -201,7 +201,7 @@ impl U64Access for Clint {
     fn write(&self, addr: &u64, data: u64) {
         assert!(
             (*addr).trailing_zeros() > 2,
-            format!("U64Access:unaligned addr:{:#x}", addr)
+            "U64Access:unaligned addr:{:#x}", addr
         );
 
         let mut timer = self.0.inner_mut();
@@ -229,13 +229,13 @@ impl U64Access for Clint {
             return timer.cnt = data;
         }
 
-        panic!("clint:U64Access Invalid addr!".to_string());
+        panic!("clint:U64Access Invalid addr!");
     }
 
     fn read(&self, addr: &u64) -> u64 {
         assert!(
             (*addr).trailing_zeros() > 2,
-            format!("U64Access:unaligned addr:{:#x}", addr)
+            "U64Access:unaligned addr:{:#x}", addr
         );
 
         let timer = self.0.inner();
@@ -253,6 +253,6 @@ impl U64Access for Clint {
             return timer.cnt;
         }
 
-        panic!("clint:U64Access Invalid addr!".to_string());
+        panic!("clint:U64Access Invalid addr!");
     }
 }

--- a/src/devices/htif.rs
+++ b/src/devices/htif.rs
@@ -58,7 +58,7 @@ impl HTIF {
         } else if desp.tohost_device() == 1 && desp.tohost_cmd() == 0 {
             desp.tohost = 0;
         } else {
-            panic!(format!("unsupported cmd:{:#x}", *desp.tohost.borrow()))
+            panic!("unsupported cmd:{:#x}", *desp.tohost.borrow())
         }
     }
 

--- a/src/devices/plic.rs
+++ b/src/devices/plic.rs
@@ -194,7 +194,7 @@ impl U32Access for Plic {
     fn write(&self, addr: &u64, data: u32) {
         assert!(
             (*addr).trailing_zeros() > 1,
-            format!("U32Access:unaligned addr:{:#x}", addr)
+            "U32Access:unaligned addr:{:#x}", addr
         );
         let inner = self.0.inner();
         if *addr >= PLIC_PRI_BASE && *addr + 4 <= PLIC_PRI_BASE + ((inner.num_src as u64) << 2) {
@@ -231,7 +231,7 @@ impl U32Access for Plic {
     fn read(&self, addr: &u64) -> u32 {
         assert!(
             (*addr).trailing_zeros() > 1,
-            format!("U32Access:unaligned addr:{:#x}", addr)
+            "U32Access:unaligned addr:{:#x}", addr
         );
         let inner = self.0.inner();
         if *addr >= PLIC_PRI_BASE && *addr + 4 <= PLIC_PRI_BASE + ((inner.num_src as u64) << 2) {
@@ -275,7 +275,7 @@ impl U64Access for Plic {
     fn write(&self, addr: &u64, data: u64) {
         assert!(
             (*addr).trailing_zeros() > 2,
-            format!("U64Access:unaligned addr:{:#x}", addr)
+            "U64Access:unaligned addr:{:#x}", addr
         );
         U32Access::write(self, addr, data as u32);
         U32Access::write(self, &(*addr + 4), (data >> 32) as u32);
@@ -284,7 +284,7 @@ impl U64Access for Plic {
     fn read(&self, addr: &u64) -> u64 {
         assert!(
             (*addr).trailing_zeros() > 2,
-            format!("U64Access:unaligned addr:{:#x}", addr)
+            "U64Access:unaligned addr:{:#x}", addr
         );
         U32Access::read(self, addr) as u64 | ((U32Access::read(self, &(*addr + 4)) as u64) << 32)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate paste;
 extern crate terminus_spaceport;
 extern crate terminus_vault;
 
-mod prelude;
+pub mod prelude;
 
 pub use prelude::*;
 

--- a/src/processor/extensions/f/mod.rs
+++ b/src/processor/extensions/f/mod.rs
@@ -112,7 +112,7 @@ impl ExtensionF {
                     }
                 });
             };
-        };
+        }
         macro_rules! deleg_fcsr_get {
             ($src:ident, $getter:ident, $transform:ident) => {
                 e.csrs.$src().$transform({
@@ -120,13 +120,13 @@ impl ExtensionF {
                     move |_| csrs.fcsr().$getter()
                 });
             };
-        };
+        }
         macro_rules! deleg_fcsr {
             ($src:ident, $getter:ident, $get_transform:ident, $setter:ident, $set_transform:ident) => {
                 deleg_fcsr_get!($src, $getter, $get_transform);
                 deleg_fcsr_set!($src, $setter, $set_transform);
             };
-        };
+        }
         deleg_fcsr!(frm_mut, frm, frm_transform, set_frm, set_frm_transform);
         deleg_fcsr!(fflags_mut, nx, nx_transform, set_nx, set_nx_transform);
         deleg_fcsr!(fflags_mut, uf, uf_transform, set_uf, set_uf_transform);

--- a/src/processor/mmu/pte.rs
+++ b/src/processor/mmu/pte.rs
@@ -365,7 +365,7 @@ impl Vaddr {
             PTE_SV32 => Vaddr::Sv32(Sv32Vaddr(addr)),
             PTE_SV39 => Vaddr::Sv39(Sv39Vaddr(addr)),
             PTE_SV48 => Vaddr::Sv48(Sv48Vaddr(addr)),
-            _ => panic!(format!("unsupported PteMode {:?}", mode)),
+            _ => panic!("unsupported PteMode {:?}", mode),
         }
     }
     pt_const_export!(Vaddr, pub offset, RegT);
@@ -415,7 +415,7 @@ impl Pte {
             PTE_SV32 => Pte::Sv32(Sv32Pte(value)),
             PTE_SV39 => Pte::Sv39(Sv39Pte(value)),
             PTE_SV48 => Pte::Sv48(Sv48Pte(value)),
-            _ => panic!(format!("unsupported PteMode {:?}", mode)),
+            _ => panic!("unsupported PteMode {:?}", mode),
         }
     }
     pub fn load(info: &PteInfo, bus: &Rc<dyn Bus>, addr: &u64) -> Result<Pte, u64> {

--- a/src/processor/privilege/s/mod.rs
+++ b/src/processor/privilege/s/mod.rs
@@ -34,7 +34,7 @@ impl PrivS {
                     });
                 }
             };
-        };
+        }
         deleg_sstatus!(upie);
         deleg_sstatus!(sie);
         deleg_sstatus!(upie);
@@ -59,7 +59,7 @@ impl PrivS {
                     });
                 }
             };
-        };
+        }
         s.csrs.sip_mut().set_ssip_transform({
             let csrs = (*m).clone();
             move |field| {
@@ -98,7 +98,7 @@ impl PrivS {
                     });
                 }
             };
-        };
+        }
         deleg_sie!(usip, usie);
         deleg_sie!(ssip, ssie);
         deleg_sie!(utip, utie);

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -267,7 +267,7 @@ impl System {
                     BytesAccess::write(&*region, &addr, head).unwrap();
                     load(space, region.info.base + region.info.size, tails)
                 }
-            };
+            }
             load(&*self.bus.space(), addr, data)
         }) {
             Ok(_) => Ok(()),

--- a/top_tests/decode_bench.rs
+++ b/top_tests/decode_bench.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use terminus::processor::decode::*;
+use terminus::prelude::*;
 use test::Bencher;
 
 #[bench]

--- a/top_tests/riscv_tests.rs
+++ b/top_tests/riscv_tests.rs
@@ -48,7 +48,7 @@ impl RsicvTestRunner {
         if valid {
             if !riscv_test(xlen, name, self.debug, num_cores) {
                 term_exit();
-                assert!(false, format!("{} fail!", name))
+                assert!(false, "{} fail!", name)
             }
             self.tests_cnt += 1;
             println!("{}", format!("{} pass!", name));


### PR DESCRIPTION
Remove unneeded format!()s, unneeded to_string()s, and unneeded semicolons. 

Also fix the compile error for the decode benchmark.